### PR TITLE
Adding unofficial code for Kosovo

### DIFF
--- a/lib/iso_country_codes/iso_3166_1.rb
+++ b/lib/iso_country_codes/iso_3166_1.rb
@@ -1496,6 +1496,12 @@ class IsoCountryCodes
       self.alpha2  = %q{ZW}
       self.alpha3  = %q{ZWE}
     end
+    class XKX < Code #:nodoc:
+      self.numeric = %q{}
+      self.name    = %q{Kosovo}
+      self.alpha2  = %q{XK}
+      self.alpha3  = %q{XKX}
+    end
   end # end Code
 end # IsoCountryCodes
 

--- a/overrides.yml
+++ b/overrides.yml
@@ -1,3 +1,7 @@
 ---
 "TWN":
   :name: "Taiwan"
+"XKX":
+  :name: "Kosovo"
+  :alpha2: "XK"
+  :alpha3: "XKX"


### PR DESCRIPTION
Kosovo does not have an approved ISO code. However, there is an unofficial code:

    Kosovo is a disputed territory and partially recognized state in Southeastern Europe that declared independence from Serbia in February 2008 as the Republic of Kosovo. Kosovo is landlocked in the central Balkan Peninsula
    The unofficial 2 and 3-digit codes are used by the European Commission and others until Kosovo is assigned an ISO code. XK, XKX. (from 2016)
    https://countrycode.org/kosovo

The code for this PR was generated using the override system.